### PR TITLE
agent plugin: report each btrfs fs only once

### DIFF
--- a/src/local/share/check_mk/agents/plugins/btrfs_health
+++ b/src/local/share/check_mk/agents/plugins/btrfs_health
@@ -1,11 +1,22 @@
-#!/bin/sh
+#!/bin/bash
 
 # Author: Matthias Maderer
 # E-Mail: edvler@edvler-blog.de
 # URL: https://github.com/edvler/check_mk-btrfs_health
 # License: GPLv2
 
-mounts_btrfs=$(mount | grep btrfs | awk '{ print $3 }')
+export LC_ALL=C
+
+mounts_btrfs=""
+devices_btrfs="$(awk '/ btrfs / { print $1 }' < /proc/mounts | sort | uniq)"
+
+for dev in $devices_btrfs; do
+    mounts_btrfs="${mounts_btrfs} "$(awk "\$1 == \"${dev}\" { print \$2; exit }" < /proc/mounts)
+done
+
+mounts_btrfs=${mounts_btrfs# }
+
+test -z $mounts_btrfs && exit
 
 echo "<<<btrfs_health_dstats>>>"
 btrfs --version


### PR DESCRIPTION
Often btrfs filesystems are mounted multiple times, especially when subvolumes are used. In that case each mount point appears in /proc/mounts with the same device but different mount points.

The scrub statistics are per device, though, not per subvolume. Therefore it doesn't make sense to list a device more than once.

With this change only the first mount point for each device will be listed.

Example: on one of my servers there are two btrfs filesystems, but each one is mounted
multiple times:

```
/dev/mapper/fast-root / btrfs rw,noatime,ssd,space_cache,user_subvol_rm_allowed,subvolid=260,subvol=/root 0 0
/dev/mapper/fast-root /home/mosu/dl btrfs rw,noatime,ssd,space_cache,user_subvol_rm_allowed,subvolid=257,subvol=/home-mosu-dl 0 0
/dev/mapper/fast-root /home/mosu/tmp btrfs rw,noatime,ssd,space_cache,user_subvol_rm_allowed,subvolid=258,subvol=/home-mosu-tmp 0 0
/dev/mapper/fast-root /srv/nfs4/hettar/buildbot-worker btrfs rw,noatime,ssd,space_cache,user_subvol_rm_allowed,subvolid=260,subvol=/root 0 0
/dev/mapper/fast-root /srv/nfs4/home btrfs rw,noatime,ssd,space_cache,user_subvol_rm_allowed,subvolid=260,subvol=/root 0 0
/dev/mapper/fast-root /srv/nfs4/nomad btrfs rw,noatime,ssd,space_cache,user_subvol_rm_allowed,subvolid=260,subvol=/root 0 0
/dev/mapper/fast-root /opt/cache btrfs rw,noatime,ssd,space_cache,user_subvol_rm_allowed,subvolid=259,subvol=/opt-cache 0 0
/dev/mapper/fast-root /srv/nfs4/home/mosu/dl btrfs rw,noatime,ssd,space_cache,user_subvol_rm_allowed,subvolid=257,subvol=/home-mosu-dl 0 0
/dev/mapper/fast-root /home/mosu/dl btrfs rw,noatime,ssd,space_cache,user_subvol_rm_allowed,subvolid=257,subvol=/home-mosu-dl 0 0
/dev/mapper/fast-root /srv/nfs4/home/mosu/tmp btrfs rw,noatime,ssd,space_cache,user_subvol_rm_allowed,subvolid=258,subvol=/home-mosu-tmp 0 0
/dev/mapper/fast-root /home/mosu/tmp btrfs rw,noatime,ssd,space_cache,user_subvol_rm_allowed,subvolid=258,subvol=/home-mosu-tmp 0 0
/dev/mapper/fast-root /srv/vms-fast btrfs rw,noatime,ssd,space_cache,user_subvol_rm_allowed,subvolid=261,subvol=/srv-vms-fast 0 0
/dev/mapper/slow-space /space btrfs rw,noatime,space_cache,subvolid=5,subvol=/ 0 0
/dev/mapper/slow-space /backup btrfs rw,noatime,space_cache,subvolid=5,subvol=/ 0 0
/dev/mapper/slow-space /ftp btrfs rw,noatime,space_cache,subvolid=5,subvol=/ 0 0
/dev/mapper/slow-space /srv/build/linux btrfs rw,noatime,space_cache,subvolid=5,subvol=/ 0 0
/dev/mapper/slow-space /srv/nfs4/space btrfs rw,noatime,space_cache,subvolid=5,subvol=/ 0 0
/dev/mapper/slow-space /srv/containers btrfs rw,noatime,space_cache,subvolid=5,subvol=/ 0 0
/dev/mapper/slow-space /srv/vms btrfs rw,noatime,space_cache,subvolid=5,subvol=/ 0 0
/dev/mapper/fast-root /var/lib/docker/btrfs btrfs rw,noatime,ssd,space_cache,user_subvol_rm_allowed,subvolid=260,subvol=/root 0 0
```

Before the change all those mount points would be listed & become three
services in CheckMK. With this change only `/` & `/space` will be listed
as those are the first mount points for each of the two devices.