### PR TITLE
add agent bakery WATO rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,22 @@ OMD[mmlan]:~$ find . -iname 'btrfs_health*.py'
 ```
 5. Goto your Check_mk webinterface. Open "Service Rules" and search for BTRFS. BTRFS Health items should appear.
 
-## On the Linux Server with the btrfs filesystem (NOT THE CHECK_MK SERVER!):
+## When using the Enterprise Edition
+1. Using the WATO's rule search, search for `btrfs_health` & create a rule of type `BTRFS health (Linux)` in the `Agent plugins` section. Enable the distribution of the plugin.
+2. Bake new agents in the bakery.
+3. On the Linux Server with the btrfs filesystem update the agent with `cmk-update-agent -v`.
+
+## When using the Raw Edition
+
+On the Linux Server with the btrfs filesystem (NOT THE CHECK_MK SERVER!), do the following:
+
 1. Copy the plugin script [src/local/share/check_mk/agents/plugins/btrfs_health](src/local/share/check_mk/agents/plugins/btrfs_health) into /usr/lib/check_mk_agent/plugins/
 2. chmod 755 /usr/lib/check_mk_agent/plugins/btrfs_health
-3. Execute the script: /usr/lib/check_mk_agent/plugins/btrfs_health. If everythings works the output should look like:
+
+## Testing the agent plugin
+
+On the Linux Server with the btrfs filesystem execute the script: `/usr/lib/check_mk_agent/plugins/btrfs_health`. If everythings works the output should look like:
+
 ```
 <<<btrfs_health_dstats>>>
 btrfs-progs v4.20.1

--- a/src/local/lib/python3/cmk/base/cee/plugins/bakery/btrfs_health.py
+++ b/src/local/lib/python3/cmk/base/cee/plugins/bakery/btrfs_health.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from typing import Any, List, Dict
+from pathlib import Path
+from .bakery_api.v1 import Plugin, PluginConfig, register, OS, FileGenerator
+
+def get_btrfs_health_files(conf: Any) -> FileGenerator:
+    yield Plugin(
+        base_os=OS.LINUX,
+        source=Path("btrfs_health"),
+        interval=None,
+        asynchronous=False,
+    )
+
+register.bakery_plugin(
+    name="btrfs_health",
+    files_function=get_btrfs_health_files,
+)

--- a/src/local/share/check_mk/web/plugins/wato/agent_bakery_btrfs_health.py
+++ b/src/local/share/check_mk/web/plugins/wato/agent_bakery_btrfs_health.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8; py-indent-offset: 4 -*-
+
+from cmk.gui.i18n import _
+from cmk.gui.plugins.wato import (
+    HostRulespec,
+    rulespec_registry,
+)
+from cmk.gui.cee.plugins.wato.agent_bakery.rulespecs.utils import RulespecGroupMonitoringAgentsAgentPlugins
+from cmk.gui.valuespec import (
+    Alternative,
+    FixedValue,
+)
+
+def _valuespec_agent_config_btrfs_health():
+    return Alternative(
+        title = _("btrfs health (Linux)"),
+        help = _("This will deploy the agent plugin <tt>btrfs_health</tt> "
+                 "for checking the health of mounted btrfs file systems."),
+        style = "dropdown",
+        elements=[
+            FixedValue(value = True, title=_("Deploy the btrfs health plugin"), totext=_("(enabled)")),
+            FixedValue(value = None, title=_("Do not deploy the btrfs health plugin"), totext=_("(disabled)")),
+        ],
+    )
+
+rulespec_registry.register(
+    HostRulespec(
+        group=RulespecGroupMonitoringAgentsAgentPlugins,
+        name="agent_config:btrfs_health",
+        valuespec=_valuespec_agent_config_btrfs_health,
+    ))


### PR DESCRIPTION
Users who are running the Enterprise Edition or above can use these rules in order to distribute the plugin via the agent bakery.